### PR TITLE
add __init__ to fix cannot find module error

### DIFF
--- a/segmenter_model_zoo/model_wrapper/__init__.py
+++ b/segmenter_model_zoo/model_wrapper/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Bin scripts package for segmenter_model_zoo."""


### PR DESCRIPTION
__init__.py is missing in model_wrapper, which causes "No module found" error. 