### PR TITLE
fix bugs when using default output tag

### DIFF
--- a/segmenter_model_zoo/bin/batch_dl_run.py
+++ b/segmenter_model_zoo/bin/batch_dl_run.py
@@ -110,7 +110,7 @@ class Seg3DStacks(object):
             elif isinstance(seg, List):
                 seg_output = zip(seg[0], seg[1])
                 for seg_img, seg_tag in seg_output:
-                    save_as_uint(seg_img, save_path, fn_core, seg_tag, self.overwrite)
+                    save_as_uint(seg_img, save_path, fn_core, self.overwrite, seg_tag)
 
         print("all files are done")
 

--- a/segmenter_model_zoo/utils.py
+++ b/segmenter_model_zoo/utils.py
@@ -34,8 +34,8 @@ def save_as_uint(
     img: np.ndarray,
     save_path: Union[str, Path],
     core_fn: str,
-    tag: str = "segmentation",
     overwrite: bool = False,
+    tag: str = "segmentation",
 ):
     """
     save the segmentation to disk as uint type
@@ -51,6 +51,9 @@ def save_as_uint(
 
     core_fn: str
         saved filename will be {core_fn}_{tag}.tiff
+
+    overwrite: bool
+        whether allowing overwriting existing results
 
     tag: str
         the tag to be added to the end of output filename


### PR DESCRIPTION
when saving the segmentation results with default suffix, the arg with default value goes in front of another arg with input value, so the default suffix is overwritten by the input value of the other arg. fix the order the args in this PR